### PR TITLE
Remove unused namespaces

### DIFF
--- a/lib/feed.xml
+++ b/lib/feed.xml
@@ -4,12 +4,8 @@ permalink: /feed/index.xml
 <?xml version="1.0" encoding="utf-8"?>
 {% capture url_base %}{% if site.url %}{{ site.url | append: site.baseurl }}{% else %}{{ site.github.url }}{% endif %}{% endcapture %}
 <rss version="2.0"
-	xmlns:content="http://purl.org/rss/1.0/modules/content/"
-	xmlns:wfw="http://wellformedweb.org/CommentAPI/"
 	xmlns:dc="http://purl.org/dc/elements/1.1/"
 	xmlns:atom="http://www.w3.org/2005/Atom"
-	xmlns:sy="http://purl.org/rss/1.0/modules/syndication/"
-	xmlns:slash="http://purl.org/rss/1.0/modules/slash/"
 	>
 <channel>
     <title xml:lang="en">{{ site.name }}</title>


### PR DESCRIPTION
Since Jekyll does not do anything with comments, let alone publish dynamically updated comment feeds, I can't imaging we'll *ever* need `wfw` or `slash`

The others I removed because they are not currently being used. It is easy enough to put them back if and when the need ever arises.