### PR TITLE
Remove references to English

### DIFF
--- a/lib/feed.xml
+++ b/lib/feed.xml
@@ -12,13 +12,12 @@ permalink: /feed/index.xml
 	xmlns:slash="http://purl.org/rss/1.0/modules/slash/"
 	>
 <channel>
-    <title xml:lang="en">{{ site.name }}</title>
+    <title>{{ site.name }}</title>
     <atom:link type="application/atom+xml" href="{{ url_base }}/feed/" rel="self"/>
     <link>{{ url_base }}</link>
     <pubDate>{{ site.time | date: "%a, %d %b %Y %H:%M:%S %z" }}</pubDate>
     <lastBuildDate>{{ site.time | date: "%a, %d %b %Y %H:%M:%S %z" }}</lastBuildDate>
     <generator>Jekyll v{{ jekyll.version }}</generator>
-   	<language>en-US</language>
     <description>{{ site.description }}</description>
     {% for post in site.posts limit:site.rss_limit %}<item>
         <title>{{ post.title }}</title>


### PR DESCRIPTION
Not all sites will use English exclusively. Since we do not know that this information is English, we should not make that claim.

It does not seem this impacts validation, as the [Jekyllrb.com sitemap](https://github.com/jekyll/jekyll/blob/master/lib/site_template/feed.xml) includes no such information.