### PR TITLE
Include Jekyll version information

### DIFF
--- a/lib/feed.xml
+++ b/lib/feed.xml
@@ -17,6 +17,7 @@ permalink: /feed/index.xml
     <link>{{ url_base }}</link>
     <pubDate>{{ site.time | date: "%a, %d %b %Y %H:%M:%S %z" }}</pubDate>
     <lastBuildDate>{{ site.time | date: "%a, %d %b %Y %H:%M:%S %z" }}</lastBuildDate>
+    <generator>Jekyll v{{ jekyll.version }}</generator>
    	<language>en-US</language>
     <description>{{ site.description }}</description>
     {% for post in site.posts limit:site.rss_limit %}<item>


### PR DESCRIPTION
This can sometimes help with debugging, and is currently done on both the [official Jekyll site](https://github.com/jekyll/jekyll/blob/c8b22a19adee0d2dfe3418349b314c35dd8c1212/site/feed.xml#L21) and the [Jekyll site template](https://github.com/jekyll/jekyll/blob/70174e8831de2d0c2b3b5cb2232c64b1efa63db0/lib/site_template/feed.xml#L13)

The other option would be to include the version number of this plugin. :sheep: