### PR TITLE
Remove front matter from template

### DIFF
--- a/lib/feed.xml
+++ b/lib/feed.xml
@@ -1,6 +1,3 @@
----
-permalink: /feed/index.xml
----
 <?xml version="1.0" encoding="utf-8"?>
 {% capture url_base %}{% if site.url %}{{ site.url | append: site.baseurl }}{% else %}{{ site.github.url }}{% endif %}{% endcapture %}
 <rss version="2.0"

--- a/lib/jekyll-rss-feed.rb
+++ b/lib/jekyll-rss-feed.rb
@@ -46,6 +46,7 @@ module Jekyll
       site_map = PageWithoutAFile.new(@site, File.dirname(__FILE__), "", "feed.xml")
       site_map.content = File.read(source_path)
       site_map.data["layout"] = nil
+      site_map.data["permalink"] = "/feed/index.xml"
       site_map.render(Hash.new, @site.site_payload)
       site_map.output.gsub(/\s*\n+/, "\n")
     end


### PR DESCRIPTION
Since we're never actually reading the front matter from the template, if we want to specify a permalink, we need to do it in Ruby.

Previously, the XML output file just contained the YAML front matter :-1: 