### PR TITLE
Do not strip newlines from post content

### DIFF
--- a/lib/jekyll-rss-feed.rb
+++ b/lib/jekyll-rss-feed.rb
@@ -44,10 +44,10 @@ module Jekyll
 
     def sitemap_content
       site_map = PageWithoutAFile.new(@site, File.dirname(__FILE__), "", "feed.xml")
-      site_map.content = File.read(source_path)
+      site_map.content = File.read(source_path).gsub(/\s*\n\s*/, "\n").gsub(/\n{%/, "{%")
       site_map.data["layout"] = nil
       site_map.render(Hash.new, @site.site_payload)
-      site_map.output.gsub(/\s*\n+/, "\n")
+      site_map.output
     end
 
     # Checks if a sitemap already exists in the site source

--- a/spec/fixtures/_posts/2015-05-12-pre.html
+++ b/spec/fixtures/_posts/2015-05-12-pre.html
@@ -1,0 +1,6 @@
+---
+---
+
+<pre>Line 1
+Line 2
+Line 3</pre>

--- a/spec/jekyll-rss-feed_spec.rb
+++ b/spec/jekyll-rss-feed_spec.rb
@@ -45,6 +45,10 @@ describe(Jekyll::JekyllRssFeed) do
     expect(contents).not_to match /<link>http:\/\/example\.org\/feeds\/atom\.xml<\/link>/
   end
 
+  it "preserves linebreaks in preformatted text in posts" do
+    expect(contents).to match /Line 1\nLine 2\nLine 3/
+  end
+
   context "with a baseurl" do
     let(:config) do
       Jekyll.configuration(Jekyll::Utils.deep_merge_hashes(overrides, {"baseurl" => "/bass"}))


### PR DESCRIPTION
Since posts may contain code blocks, or some other content with pre-formatted whitespace, we *do not* want to strip whitespace from post content.

This pull request strips whitespace from the template *before* it is rendered, rather than after. This will keep all the whitespace from the post content intact.