### PR TITLE
Validate the resulting feed

### DIFF
--- a/jekyll-rss-feed.gemspec
+++ b/jekyll-rss-feed.gemspec
@@ -18,4 +18,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "typhoeus", "~> 0.7"
+  spec.add_development_dependency "nokogiri", "~> 1.6"
+
 end

--- a/spec/jekyll-rss-feed_spec.rb
+++ b/spec/jekyll-rss-feed_spec.rb
@@ -49,6 +49,56 @@ describe(Jekyll::JekyllRssFeed) do
     expect(contents).to match /Line 1\nLine 2\nLine 3/
   end
 
+  context "parsing" do
+    let(:feed) { RSS::Parser.parse(contents) }
+
+    it "outputs an RSS feed" do
+      expect(feed.feed_type).to eql("rss")
+      expect(feed.feed_version).to eql("2.0")
+      expect(feed.encoding).to eql("UTF-8")
+    end
+
+    it "outputs the link" do
+      expect(feed.channel.link).to eql("http://example.org")
+    end
+
+    it "outputs the generator" do
+      expect(feed.channel.generator).to match(/Jekyll v\d+\.\d+\.\d+/)
+    end
+
+    it "includes the items" do
+      expect(feed.items.count).to eql(6)
+    end
+
+    it "includes item contents" do
+      post = feed.items.last
+      expect(post.title).to eql("Dec The Second")
+      expect(post.link).to eql("http://example.org/2013/12/12/dec-the-second.html")
+      expect(post.pubDate).to eql(Time.parse("2013-12-12"))
+    end
+  end
+
+  context "validation" do
+    it "validates" do
+      # See https://validator.w3.org/docs/api.html
+      url = "https://validator.w3.org/feed/check.cgi?output=soap12"
+      response = Typhoeus.post(url, body: { rawdata: contents }, accept_encoding: "gzip")
+      pending "Something went wrong with the W3 validator" unless response.success?
+      result  = Nokogiri::XML(response.body)
+      result.remove_namespaces!
+
+      result.css("warning").each do |warning|
+        warn "Validation warning: #{warning.css("text").text} on line #{warning.css("line").text} column #{warning.css("column").text}"
+      end
+
+      errors = result.css("error").map do |error|
+        "Validation error: #{error.css("text").text} on line #{error.css("line").text} column #{error.css("column").text}"
+      end
+
+      expect(result.css("validity").text).to eql("true"), errors.join("\n")
+    end
+  end
+
   context "with a baseurl" do
     let(:config) do
       Jekyll.configuration(Jekyll::Utils.deep_merge_hashes(overrides, {"baseurl" => "/bass"}))

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,7 @@
 require 'jekyll'
+require 'typhoeus'
+require 'nokogiri'
+require 'rss'
 require File.expand_path('../lib/jekyll-rss-feed', File.dirname(__FILE__))
 
 Jekyll.logger.log_level = :error


### PR DESCRIPTION
Both by parsing the RSS for expectations, and by calling the W3 validation API.

To note, there are some gems out there, but they haven't been updated in 3+ years, and given one call, things were simple enough to implement with a post request + nokigiri.

Fixes #16