### PR TITLE
Add feed_meta tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ Optional configuration options:
 
 * `rss_limit`: number of posts to be included in the feed; default `nil`
 
+### Meta tags
+
+The plugin exposes a helper tag to expose the appropriate meta tags to support automated discovery of your feed. Simply place `{% feed_meta %}` someplace in your template's `<head>` section, to output the necessary metadata.
+
 ## Contributing
 
 1. Fork it (https://github.com/jekyll/jekyll-rss-feed/fork)

--- a/lib/jekyll-rss-feed.rb
+++ b/lib/jekyll-rss-feed.rb
@@ -8,7 +8,6 @@ module Jekyll
   end
 
   class FeedMetaTag < Liquid::Tag
-
     def config
       @context.registers[:site].config
     end

--- a/lib/jekyll-rss-feed.rb
+++ b/lib/jekyll-rss-feed.rb
@@ -17,7 +17,7 @@ module Jekyll
       if config["url"]
         config["url"]
       elsif config["github"] && config["github"]["url"]
-        config.github.url
+        config["github"]["url"]
       end
     end
 

--- a/lib/jekyll-rss-feed.rb
+++ b/lib/jekyll-rss-feed.rb
@@ -7,6 +7,26 @@ module Jekyll
     end
   end
 
+  class FeedMetaTag < Liquid::Tag
+
+    def config
+      @context.registers[:site].config
+    end
+
+    def url
+      if config["url"]
+        config["url"]
+      elsif config["github"] && config["github"]["url"]
+        config.github.url
+      end
+    end
+
+    def render(context)
+      @context = context
+      "<link type=\"application/atom+xml\" rel=\"alternate\" href=\"#{url}/feed.xml\" />"
+    end
+  end
+
   class JekyllRssFeed < Jekyll::Generator
     safe true
     priority :lowest
@@ -60,3 +80,5 @@ module Jekyll
     end
   end
 end
+
+Liquid::Template.register_tag('feed_meta', Jekyll::FeedMetaTag)

--- a/spec/fixtures/_layouts/some_default.html
+++ b/spec/fixtures/_layouts/some_default.html
@@ -1,4 +1,11 @@
 ---
 ---
+<html>
+  <head>
+    {% feed_meta %}
+  </head>
+  <body>
 THIS IS MY LAYOUT
 {{ content }}
+  </body>
+</html>

--- a/spec/jekyll-rss-feed_spec.rb
+++ b/spec/jekyll-rss-feed_spec.rb
@@ -110,4 +110,12 @@ describe(Jekyll::JekyllRssFeed) do
       expect(contents).to match /<link>http:\/\/example\.org\/bass\/2013\/12\/12\/dec-the-second\.html<\/link>/
     end
   end
+
+  context "feed meta" do
+    it "renders the feed meta" do
+      index = File.read(dest_dir("index.html"))
+      expected = '<link type="application/atom+xml" rel="alternate" href="http://example.org/feed.xml" />'
+      expect(index).to include(expected)
+    end
+  end
 end


### PR DESCRIPTION
Such that `{% feed_meta %}` will output `<link type="application/atom+xml" rel="alternate" href="http://example.org/feed.xml" />`

Fixes #20