### PR TITLE
add trailing slash back in

### DIFF
--- a/lib/feed.xml
+++ b/lib/feed.xml
@@ -9,7 +9,7 @@
   <link href="{{ url_base }}{{ page.url }}" rel="self" type="application/atom+xml" />
   <link href="{{ url_base }}/" rel="alternate" type="text/html" />
   <updated>{{ site.time | date_to_xmlschema }}</updated>
-  <id>{{ url_base }}</id>
+  <id>{{ url_base }}/</id>
 
   {% if site.name %}
     <title>{{ site.name }}</title>


### PR DESCRIPTION
Revert f61d75749a45aebfa53293cee046f2896cde9d5d which removed the trailing slash in the `id`.

Without it, we get the validation warning `Validation warning: Identifier "http://example.org" is not in canonical form (the canonical form would be "http://example.org/") on line 7 column 22`.

/cc https://github.com/jekyll/jekyll-rss-feed/pull/24